### PR TITLE
Run Xloader Locally & Jobs Log File

### DIFF
--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -134,16 +134,8 @@ def xloader_submit(context, data_dict):
         task
     )
 
-    callback_url = p.toolkit.url_for(
-        "api.action",
-        ver=3,
-        logic_function="xloader_hook",
-        qualified=True
-    )
     data = {
-        'api_key': utils.get_xloader_user_apitoken(),
         'job_type': 'xloader_to_datastore',
-        'result_url': callback_url,
         'metadata': {
             'ignore_hash': data_dict.get('ignore_hash', False),
             'ckan_url': config['ckan.site_url'],
@@ -220,8 +212,6 @@ def xloader_hook(context, data_dict):
         :type sent_data: json encodable data
         :param job_id: An identifier for the job
         :type job_id: string
-        :param result_url: Callback url
-        :type result_url: url string
         :param data: Results from job.
         :type data: json encodable data
         :param requested_timestamp: Time the job started

--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -15,10 +15,6 @@ groups:
         description: |
             The username of that will be executing the actions of the xloader service.
             This user should have higher permissions.
-      - key: ckanext.xloader.api_token
-        example: eyJ0eXAiOiJKV1QiLCJh.eyJqdGkiOiJ0M2VNUFlQWFg0VU.8QgV8em4RA
-        description: |
-            Uses a specific API token for the downloading private resources.
         required: false
       - key: ckanext.xloader.formats
         example: csv application/csv xls application/vnd.ms-excel

--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -10,12 +10,12 @@ groups:
             Postgresql database.
         validators: not_missing
         required: true
-      - key: ckanext.xloader.api_token
-        example: eyJ0eXAiOiJKV1QiLCJh.eyJqdGkiOiJ0M2VNUFlQWFg0VU.8QgV8em4RA
+      - key: ckanext.xloader.user
+        example: xloader_system
         description: |
-            Uses a specific API token for the xloader_submit action instead of the
-            apikey of the site_user. Will be mandatory when dropping support for
-            CKAN 2.9.
+            The username of a sysadmin that will be executing the actions of the
+            xloader service. This user should also have an API token to download
+            private resource files.
         required: false
       - key: ckanext.xloader.formats
         example: csv application/csv xls application/vnd.ms-excel

--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -13,9 +13,12 @@ groups:
       - key: ckanext.xloader.user
         example: xloader_system
         description: |
-            The username of a sysadmin that will be executing the actions of the
-            xloader service. This user should also have an API token to download
-            private resource files.
+            The username of that will be executing the actions of the xloader service.
+            This user should have higher permissions.
+      - key: ckanext.xloader.api_token
+        example: eyJ0eXAiOiJKV1QiLCJh.eyJqdGkiOiJ0M2VNUFlQWFg0VU.8QgV8em4RA
+        description: |
+            Uses a specific API token for the downloading private resources.
         required: false
       - key: ckanext.xloader.formats
         example: csv application/csv xls application/vnd.ms-excel

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -253,8 +253,9 @@ def _download_resource_data(resource, data, logger):
         raise JobError('Only uploaded files can be added to the Data Store.')
 
     # get url from uploader (canada fork only)
+    #TODO: upstream contribution??
     upload = get_resource_uploader(resource)
-    url = upload.get_path(resource['id'], context=get_xloader_user_context())
+    url = upload.get_path(resource['id'])
     logger.info('Resource %s using uploader: %s', resource['id'], type(upload).__name__)
 
     # check scheme

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -15,18 +15,13 @@ import requests
 from rq import get_current_job
 import sqlalchemy as sa
 
-from ckan import model
-from ckan.plugins.toolkit import get_action, asbool, ObjectNotFound, config, check_ckan_version
+from ckan.plugins.toolkit import get_action, asbool, ObjectNotFound, config
 
 from . import loader
 from . import db
 from .job_exceptions import JobError, HTTPError, DataTooBigError, FileCouldNotBeLoadedError
-from .utils import set_resource_metadata
+from .utils import set_resource_metadata, get_xloader_user_context, get_xloader_user_apitoken
 
-try:
-    from ckan.lib.api_token import get_user_from_token
-except ImportError:
-    get_user_from_token = None
 
 SSL_VERIFY = asbool(config.get('ckanext.xloader.ssl_verify', True))
 if not SSL_VERIFY:
@@ -39,9 +34,7 @@ DOWNLOAD_TIMEOUT = 30
 
 
 # input = {
-# 'api_key': user['apikey'],
 # 'job_type': 'xloader_to_datastore',
-# 'result_url': callback_url,
 # 'metadata': {
 #     'ignore_hash': data_dict.get('ignore_hash', False),
 #     'ckan_url': site_url,
@@ -66,9 +59,7 @@ def xloader_data_into_datastore(input):
     # be a duplicate or not
     job_dict = dict(metadata=input['metadata'],
                     status='running')
-    callback_xloader_hook(result_url=input['result_url'],
-                          api_key=input['api_key'],
-                          job_dict=job_dict)
+    callback_xloader_hook(job_dict=job_dict)
 
     job_id = get_current_job().id
     errored = False
@@ -93,9 +84,7 @@ def xloader_data_into_datastore(input):
         errored = True
     finally:
         # job_dict is defined in xloader_hook's docstring
-        is_saved_ok = callback_xloader_hook(result_url=input['result_url'],
-                                            api_key=input['api_key'],
-                                            job_dict=job_dict)
+        is_saved_ok = callback_xloader_hook(job_dict=job_dict)
         errored = errored or not is_saved_ok
     return 'error' if errored else None
 
@@ -128,19 +117,25 @@ def xloader_data_into_datastore_(input, job_dict):
     # also show logs on stderr
     logger.addHandler(logging.StreamHandler())
     logger.setLevel(logging.DEBUG)
+    # also log to file
+    if config.get('ckanext.xloader.jobs_log'):
+        file_handler = logging.FileHandler(config.get('ckanext.xloader.jobs_log'))
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)-5.5s [%(name)s] %(message)s'))
+        logger.addHandler(file_handler)
+
 
     validate_input(input)
 
     data = input['metadata']
 
     resource_id = data['resource_id']
-    api_key = input.get('api_key')
     try:
-        resource, dataset = get_resource_and_dataset(resource_id, api_key)
+        resource, dataset = get_resource_and_dataset(resource_id)
     except (JobError, ObjectNotFound):
         # try again in 5 seconds just in case CKAN is slow at adding resource
         time.sleep(5)
-        resource, dataset = get_resource_and_dataset(resource_id, api_key)
+        resource, dataset = get_resource_and_dataset(resource_id)
     resource_ckan_url = '/dataset/{}/resource/{}' \
         .format(dataset['name'], resource['id'])
     logger.info('Express Load starting: %s', resource_ckan_url)
@@ -152,8 +147,7 @@ def xloader_data_into_datastore_(input, job_dict):
         return
 
     # download resource
-    tmp_file, file_hash = _download_resource_data(resource, data, api_key,
-                                                  logger)
+    tmp_file, file_hash = _download_resource_data(resource, data, logger)
 
     if (resource.get('hash') == file_hash
             and not data.get('ignore_hash')):
@@ -173,9 +167,7 @@ def xloader_data_into_datastore_(input, job_dict):
             resource_id=resource['id'], logger=logger)
         set_datastore_active(data, resource, logger)
         job_dict['status'] = 'running_but_viewable'
-        callback_xloader_hook(result_url=input['result_url'],
-                              api_key=api_key,
-                              job_dict=job_dict)
+        callback_xloader_hook(job_dict=job_dict)
         logger.info('Data now available to users: %s', resource_ckan_url)
         loader.create_column_indexes(
             fields=fields,
@@ -238,12 +230,11 @@ def xloader_data_into_datastore_(input, job_dict):
     logger.info('Express Load completed')
 
 
-def _download_resource_data(resource, data, api_key, logger):
+def _download_resource_data(resource, data, logger):
     '''Downloads the resource['url'] as a tempfile.
 
     :param resource: resource (i.e. metadata) dict (from the job dict)
     :param data: job dict - may be written to during this function
-    :param api_key: CKAN api key - needed to obtain resources that are private
     :param logger:
 
     If the download is bigger than MAX_CONTENT_LENGTH then it just downloads a
@@ -286,7 +277,7 @@ def _download_resource_data(resource, data, api_key, logger):
         if resource.get('url_type') == 'upload':
             # If this is an uploaded file to CKAN, authenticate the request,
             # otherwise we won't get file from private resources
-            headers['X-CKAN-API-Key'] = api_key
+            headers['X-CKAN-API-Key'] = get_xloader_user_apitoken()
 
             # Add a constantly changing parameter to bypass URL caching.
             # If we're running XLoader, then either the resource has
@@ -413,36 +404,20 @@ def set_datastore_active(data, resource, logger):
     set_resource_metadata(update_dict=data)
 
 
-def callback_xloader_hook(result_url, api_key, job_dict):
-    '''Tells CKAN about the result of the xloader (i.e. calls the callback
+def callback_xloader_hook(job_dict):
+    '''Tells CKAN about the result of the xloader (i.e. calls the action
     function 'xloader_hook'). Usually called by the xloader queue job.
-    Returns whether it managed to call the sh
+
+    Returns whether it managed to call the xloader_hook action or not
     '''
-    api_key_from_job = job_dict.pop('api_key', None)
-    if not api_key:
-        api_key = api_key_from_job
-    headers = {'Content-Type': 'application/json'}
-    if api_key:
-        if ':' in api_key:
-            header, key = api_key.split(':')
-        else:
-            header, key = 'Authorization', api_key
-        headers[header] = key
-
-    log = logging.getLogger(__name__)
-    log.info("Sending data to xloader hook callback at: %s", result_url)
-
     try:
-        result = requests.post(
-            result_url,
-            data=json.dumps(job_dict, cls=DatetimeJsonEncoder),
-            verify=SSL_VERIFY,
-            headers=headers)
-    except requests.ConnectionError:
-        log.warning("Failed to call xloader hook callback at: %s", result_url)
+        get_action('xloader_hook')(get_xloader_user_context(), job_dict)
+    except Exception as e:
+        log = logging.getLogger(__name__)
+        log.warning("Failed to call xloader_hook action: %s", e)
         return False
 
-    return result.status_code == requests.codes.ok
+    return True
 
 
 def validate_input(input):
@@ -456,8 +431,6 @@ def validate_input(input):
         raise JobError('No id provided.')
     if 'ckan_url' not in data:
         raise JobError('No ckan_url provided.')
-    if not input.get('api_key'):
-        raise JobError('No CKAN API key provided')
 
 
 def update_resource(resource, patch_only=False):
@@ -467,55 +440,20 @@ def update_resource(resource, patch_only=False):
     or patch the given CKAN resource for file hash
     """
     action = 'resource_update' if not patch_only else 'resource_patch'
-    user = get_action('get_site_user')({'ignore_auth': True}, {})
-    context = {
-        'ignore_auth': True,
-        'user': user['name'],
-        'auth_user_obj': None
-    }
+    context = get_xloader_user_context()
+    context['ignore_auth'] = True
+    context['auth_user_obj'] = None
     get_action(action)(context, resource)
 
 
-def _get_user_from_key(api_key_or_token):
-    """ Gets the user using the API Token or API Key.
-
-    This method provides backwards compatibility for CKAN 2.9 that
-    supported both methods and previous CKAN versions supporting
-    only API Keys.
-    """
-    user = None
-    if get_user_from_token:
-        user = get_user_from_token(api_key_or_token)
-    if not user:
-        user = model.Session.query(model.User).filter_by(
-            apikey=api_key_or_token
-        ).first()
-    return user
-
-
-def get_resource_and_dataset(resource_id, api_key):
+def get_resource_and_dataset(resource_id):
     """
     Gets available information about the resource and its dataset from CKAN
     """
-    context = None
-    user = _get_user_from_key(api_key)
-    if user is not None:
-        context = {'user': user.name}
-
+    context = get_xloader_user_context()
     res_dict = get_action('resource_show')(context, {'id': resource_id})
     pkg_dict = get_action('package_show')(context, {'id': res_dict['package_id']})
     return res_dict, pkg_dict
-
-
-def get_url(action, ckan_url):
-    """
-    Get url for ckan action
-    """
-    if not urlsplit(ckan_url).scheme:
-        ckan_url = 'http://' + ckan_url.lstrip('/')
-    ckan_url = ckan_url.rstrip('/')
-    return '{ckan_url}/api/3/action/{action}'.format(
-        ckan_url=ckan_url, action=action)
 
 
 def check_response(response, request_url, who, good_status=(201, 200),

--- a/ckanext/xloader/migration/xloader/README
+++ b/ckanext/xloader/migration/xloader/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/ckanext/xloader/migration/xloader/alembic.ini
+++ b/ckanext/xloader/migration/xloader/alembic.ini
@@ -1,0 +1,74 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = %(here)s
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+#truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to /srv/app/ckan/registry/src/ckanext-xloader/ckanext/xloader/migration/xloader/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat /srv/app/ckan/registry/src/ckanext-xloader/ckanext/xloader/migration/xloader/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/ckanext/xloader/migration/xloader/env.py
+++ b/ckanext/xloader/migration/xloader/env.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import with_statement
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from logging.config import fileConfig
+
+import os
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+name = os.path.basename(os.path.dirname(__file__))
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+
+    url = config.get_main_option(u"sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True,
+        version_table=u'{}_alembic_version'.format(name)
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix=u'sqlalchemy.',
+        poolclass=pool.NullPool)
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            version_table=u'{}_alembic_version'.format(name)
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/ckanext/xloader/migration/xloader/script.py.mako
+++ b/ckanext/xloader/migration/xloader/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/ckanext/xloader/migration/xloader/versions/84583fc5153e_remove_api_key_and_result_url_columns.py
+++ b/ckanext/xloader/migration/xloader/versions/84583fc5153e_remove_api_key_and_result_url_columns.py
@@ -1,0 +1,26 @@
+"""Remove api_key and result_url columns
+
+Revision ID: 84583fc5153e
+Revises:
+Create Date: 2023-11-10 17:10:10.636653
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '84583fc5153e'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column('jobs', 'result_url')
+    op.drop_column('jobs', 'api_key')
+
+
+def downgrade():
+    op.add_column('jobs', sa.Column('result_url', sa.UnicodeText))
+    op.add_column('jobs', sa.Column('api_key', sa.UnicodeText))

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -84,20 +84,6 @@ def resource_data(id, resource_id):
     )
 
 
-def get_xloader_user_apitoken():
-    # type: () -> str
-    """ Returns the API Token for authentication.
-
-    xloader downloads files and the API key is needed for private resources.
-    """
-    token = p.toolkit.config.get('ckanext.xloader.api_token', None)
-    if token:
-        return token
-
-    user = p.toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
-    return user["apikey"]
-
-
 def get_xloader_user_context():
     # type: () -> Context|dict
     """ Returns the Xloader user.

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -85,18 +85,32 @@ def resource_data(id, resource_id):
 
 
 def get_xloader_user_apitoken():
+    # type: () -> str
     """ Returns the API Token for authentication.
 
-    xloader actions require an authenticated user to perform the actions. This
-    method returns the api_token set in the config file and defaults to the
-    site_user.
+    xloader downloads files and the API key is needed for private resources.
     """
-    api_token = p.toolkit.config.get('ckanext.xloader.api_token', None)
-    if api_token:
-        return api_token
+    user = p.toolkit.config.get('ckanext.xloader.user', None)
+    if user and user.get('apikey'):
+        return user.get('apikey')
 
-    site_user = p.toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
-    return site_user["apikey"]
+    user = p.toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
+    return user["apikey"]
+
+
+def get_xloader_user_context():
+    # type: () -> Context|dict
+    """ Returns the Xloader user.
+
+    xloader actions require an authenticated user to perform the actions. This
+    method returns the context for actions.
+    """
+    user = p.toolkit.config.get('ckanext.xloader.user', None)
+    if user:
+        return {"user": user['name']}
+
+    user = p.toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
+    return {"user": user['name']}
 
 
 def set_resource_metadata(update_dict):

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -90,9 +90,9 @@ def get_xloader_user_apitoken():
 
     xloader downloads files and the API key is needed for private resources.
     """
-    user = p.toolkit.config.get('ckanext.xloader.user', None)
-    if user and user.get('apikey'):
-        return user.get('apikey')
+    token = p.toolkit.config.get('ckanext.xloader.api_token', None)
+    if token:
+        return token
 
     user = p.toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
     return user["apikey"]
@@ -107,7 +107,7 @@ def get_xloader_user_context():
     """
     user = p.toolkit.config.get('ckanext.xloader.user', None)
     if user:
-        return {"user": user['name']}
+        return {"user": user}
 
     user = p.toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
     return {"user": user['name']}


### PR DESCRIPTION
feat(dev): replaced xloader hook http with action call;

- Removed `result_url` and `api_key` from the database and code.
- Added migration script for column removals.
- Replaced the HTTP request to the xloader hook to just an action call.
- Replaced the `api_token` config option with `user` for action contexts.