### PR TITLE
Temporary Fix for Re-Submit to Validation from Xloader Complete

### DIFF
--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -453,6 +453,10 @@ def update_resource(resource, patch_only=False):
     context = get_xloader_user_context()
     context['ignore_auth'] = True
     context['auth_user_obj'] = None
+    # (canada fork only) if Xloader is running, the Resource has
+    # already passed validation and does not need it again.
+    # TODO: remove after upstream fix to IResourceController hooks
+    context['_validation_performed'] = True
     get_action(action)(context, resource)
 
 


### PR DESCRIPTION
temp(fix): fix resubmit to validation;

- Adds context key,value to prevent re-submitting to Validation and making a single loop.

@wardi as discussed, the upstream fix (https://github.com/ckan/ckan/pull/7968) will solve all of these issues. But for now, we can put in some simple temporary fixes to get our data relaxed on our site