### PR TITLE
Hide excessive entries on the resource_data page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,16 @@ can access the CKAN config, db and logging directly and avoids many HTTP calls.
 This simplification makes sense because the xloader job doesn't need to do much
 processing - mainly it is streaming the CSV file from disk into PostgreSQL.
 
+It is still entirely possible to run the XLoader worker on a separate server,
+if that is desired. The worker needs the following:
+
+- A copy of CKAN installed in the same Python virtualenv (but not running).
+- A copy of the CKAN config file.
+- Access to the Redis instance that the running CKAN app uses to store jobs.
+- Access to the database.
+
+You can then run it via `ckan jobs worker` as below.
+
 Caveat - column types
 ---------------------
 

--- a/ckanext/xloader/templates/xloader/resource_data.html
+++ b/ckanext/xloader/templates/xloader/resource_data.html
@@ -61,7 +61,25 @@
   {% if status.status and status.task_info and show_table %}
     <h3>{{ _('Upload Log') }}</h3>
     <ul class="activity">
-      {% for item in status.task_info.logs %}
+      {% set items = status.task_info.logs %}
+      {% set rows = rows or 50 %}
+      {% set skipped_rows = (items | length) - (rows * 2) %}
+      {% if skipped_rows > 1 %}
+        <li class="item no-avatar">
+          <i class="fa icon fa-exclamation"></i>
+          <p>
+            {{ skipped_rows }} out of {{ items | length }} logs will be hidden.
+            <br>
+            <span class="date">
+              <a href="?rows={{rows * 2}}">Show more</a>&nbsp; &nbsp;<a href="?rows={{ items | length }}">Show all</a>
+            </span>
+          </p>
+        </li>
+      {% endif %}
+      {% for item in items %}
+        {# Truncate very long loops, showing just the start and end #}
+        {% if loop.index <= rows or loop.revindex <= rows
+           or (loop.index == rows + 1 and loop.revindex == rows + 1) %}
         {% set icon = 'ok' if item.level == 'INFO' else 'exclamation' %}
         {% set class = ' failure' if icon == 'exclamation' else ' success' %}
         {% set popover_content = 'test' %}
@@ -77,6 +95,18 @@
             </span>
           </p>
         </li>
+        {% elif loop.index == rows + 1 %}
+          <li class="item no-avatar">
+            <i class="fa icon fa-exclamation"></i>
+            <p>
+              Skipping {{ skipped_rows }} logs...
+              <br>
+              <span class="date">
+                <a href="?rows={{rows * 2}}">Show more</a>&nbsp; &nbsp;<a href="?rows={{ items | length }}">Show all</a>
+              </span>
+            </p>
+          </li>
+        {% endif %}
       {% endfor %}
       <li class="item no-avatar">
         <i class="fa icon fa-info"></i>

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -64,8 +64,12 @@ class TestLoadBase(object):
         # SELECT column_name FROM information_schema.columns WHERE table_name='test1';
         c = Session.connection()
         sql = (
-            "SELECT column_name FROM information_schema.columns "
-            "WHERE table_name='{}';".format(table_name)
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name='{}'
+            ORDER BY ordinal_position;
+            """.format(table_name)
         )
         results = c.execute(sql)
         records = results.fetchall()
@@ -74,8 +78,12 @@ class TestLoadBase(object):
     def _get_column_types(self, Session, table_name):
         c = Session.connection()
         sql = (
-            "SELECT udt_name FROM information_schema.columns "
-            "WHERE table_name='{}';".format(table_name)
+            """
+            SELECT udt_name
+            FROM information_schema.columns
+            WHERE table_name='{}'
+            ORDER BY ordinal_position;
+            """.format(table_name)
         )
         results = c.execute(sql)
         records = results.fetchall()

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -85,8 +85,8 @@ class TestLoadBase(object):
 class TestLoadCsv(TestLoadBase):
     def test_simple(self, Session):
         csv_filepath = get_sample_filepath("simple.csv")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         loader.load_csv(
             csv_filepath,
             resource_id=resource_id,
@@ -95,7 +95,7 @@ class TestLoadCsv(TestLoadBase):
         )
 
         assert self._get_records(
-            Session, "test1", limit=1, exclude_full_text_column=False
+            Session, resource_id, limit=1, exclude_full_text_column=False
         ) == [
             (
                 1,
@@ -105,7 +105,7 @@ class TestLoadCsv(TestLoadBase):
                 u"Galway",
             )
         ]
-        assert self._get_records(Session, "test1") == [
+        assert self._get_records(Session, resource_id) == [
             (1, u"2011-01-01", u"1", u"Galway"),
             (2, u"2011-01-02", u"-1", u"Galway"),
             (3, u"2011-01-03", u"0", u"Galway"),
@@ -113,14 +113,14 @@ class TestLoadCsv(TestLoadBase):
             (5, None, None, u"Berkeley"),
             (6, u"2011-01-03", u"5", None),
         ]
-        assert self._get_column_names(Session, "test1") == [
+        assert self._get_column_names(Session, resource_id) == [
             u"_id",
             u"_full_text",
             u"date",
             u"temperature",
             u"place",
         ]
-        assert self._get_column_types(Session, "test1") == [
+        assert self._get_column_types(Session, resource_id) == [
             u"int4",
             u"tsvector",
             u"text",
@@ -130,8 +130,8 @@ class TestLoadCsv(TestLoadBase):
 
     def test_simple_with_indexing(self, Session):
         csv_filepath = get_sample_filepath("simple.csv")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         fields = loader.load_csv(
             csv_filepath,
             resource_id=resource_id,
@@ -144,7 +144,7 @@ class TestLoadCsv(TestLoadBase):
 
         assert (
             self._get_records(
-                Session, "test1", limit=1, exclude_full_text_column=False
+                Session, resource_id, limit=1, exclude_full_text_column=False
             )[0][1]
             == "'-01':2,3 '1':4 '2011':1 'galway':5"
         )
@@ -155,8 +155,8 @@ class TestLoadCsv(TestLoadBase):
         # to get the test file:
         # curl -o ckanext/xloader/tests/samples/boston_311.csv https://data.boston.gov/dataset/8048697b-ad64-4bfc-b090-ee00169f2323/resource/2968e2c0-d479-49ba-a884-4ef523ada3c0/download/311.csv  # noqa
         csv_filepath = get_sample_filepath("boston_311.csv")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         import time
 
         t0 = time.time()
@@ -179,8 +179,8 @@ class TestLoadCsv(TestLoadBase):
         # to create the test file:
         # head -n 100001 ckanext/xloader/tests/samples/boston_311.csv > ckanext/xloader/tests/samples/boston_311_sample5.csv
         csv_filepath = get_sample_filepath("boston_311_sample5.csv")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         import time
 
         t0 = time.time()
@@ -199,8 +199,8 @@ class TestLoadCsv(TestLoadBase):
 
     def test_boston_311(self, Session):
         csv_filepath = get_sample_filepath("boston_311_sample.csv")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         loader.load_csv(
             csv_filepath,
             resource_id=resource_id,
@@ -208,7 +208,7 @@ class TestLoadCsv(TestLoadBase):
             logger=logger,
         )
 
-        records = self._get_records(Session, "test1")
+        records = self._get_records(Session, resource_id)
         print(records)
         assert records == [
             (
@@ -308,8 +308,8 @@ class TestLoadCsv(TestLoadBase):
                 u"Citizens Connect App",
             ),
         ]  # noqa
-        print(self._get_column_names(Session, "test1"))
-        assert self._get_column_names(Session, "test1") == [
+        print(self._get_column_names(Session, resource_id))
+        assert self._get_column_names(Session, resource_id) == [
             u"_id",
             u"_full_text",
             u"CASE_ENQUIRY_ID",
@@ -342,16 +342,16 @@ class TestLoadCsv(TestLoadBase):
             u"Longitude",
             u"Source",
         ]  # noqa
-        print(self._get_column_types(Session, "test1"))
-        assert self._get_column_types(Session, "test1") == [
+        print(self._get_column_types(Session, resource_id))
+        assert self._get_column_types(Session, resource_id) == [
             u"int4",
             u"tsvector",
         ] + [u"text"] * (len(records[0]) - 1)
 
     def test_brazilian(self, Session):
         csv_filepath = get_sample_filepath("brazilian_sample.csv")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         loader.load_csv(
             csv_filepath,
             resource_id=resource_id,
@@ -359,7 +359,7 @@ class TestLoadCsv(TestLoadBase):
             logger=logger,
         )
 
-        records = self._get_records(Session, "test1")
+        records = self._get_records(Session, resource_id)
         print(records)
         assert records[0] == (
             1,
@@ -459,8 +459,8 @@ class TestLoadCsv(TestLoadBase):
             None,
             None,
         )  # noqa
-        print(self._get_column_names(Session, "test1"))
-        assert self._get_column_names(Session, "test1") == [
+        print(self._get_column_names(Session, resource_id))
+        assert self._get_column_names(Session, resource_id) == [
             u"_id",
             u"_full_text",
             u"NU_ANO_CENSO",
@@ -559,16 +559,16 @@ class TestLoadCsv(TestLoadBase):
             u"PROVA_MEAN_MAT_I_MUN",
             u"PROVA_MEAN_MAT_T_MUN",
         ]  # noqa
-        print(self._get_column_types(Session, "test1"))
-        assert self._get_column_types(Session, "test1") == [
+        print(self._get_column_types(Session, resource_id))
+        assert self._get_column_types(Session, resource_id) == [
             u"int4",
             u"tsvector",
         ] + [u"text"] * (len(records[0]) - 1)
 
     def test_german(self, Session):
         csv_filepath = get_sample_filepath("german_sample.csv")
-        resource_id = "test_german"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         loader.load_csv(
             csv_filepath,
             resource_id=resource_id,
@@ -576,7 +576,7 @@ class TestLoadCsv(TestLoadBase):
             logger=logger,
         )
 
-        records = self._get_records(Session, "test_german")
+        records = self._get_records(Session, resource_id)
         print(records)
         assert records[0] == (
             1,
@@ -591,8 +591,8 @@ class TestLoadCsv(TestLoadBase):
             u"24221",
             u"672",
         )
-        print(self._get_column_names(Session, "test_german"))
-        assert self._get_column_names(Session, "test_german") == [
+        print(self._get_column_names(Session, resource_id))
+        assert self._get_column_names(Session, resource_id) == [
             u"_id",
             u"_full_text",
             u"Stadtname",
@@ -606,16 +606,16 @@ class TestLoadCsv(TestLoadBase):
             u"Schuler_Berufsausbildung_2010/2011",
             u"Schuler_andere allgemeinbildende Schulen_2010/2011",
         ]
-        print(self._get_column_types(Session, "test_german"))
-        assert self._get_column_types(Session, "test_german") == [
+        print(self._get_column_types(Session, resource_id))
+        assert self._get_column_types(Session, resource_id) == [
             u"int4",
             u"tsvector",
         ] + [u"text"] * (len(records[0]) - 1)
 
     def test_reload(self, Session):
         csv_filepath = get_sample_filepath("simple.csv")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         loader.load_csv(
             csv_filepath,
             resource_id=resource_id,
@@ -631,15 +631,15 @@ class TestLoadCsv(TestLoadBase):
             logger=logger,
         )
 
-        assert len(self._get_records(Session, "test1")) == 6
-        assert self._get_column_names(Session, "test1") == [
+        assert len(self._get_records(Session, resource_id)) == 6
+        assert self._get_column_names(Session, resource_id) == [
             u"_id",
             u"_full_text",
             u"date",
             u"temperature",
             u"place",
         ]
-        assert self._get_column_types(Session, "test1") == [
+        assert self._get_column_types(Session, resource_id) == [
             u"int4",
             u"tsvector",
             u"text",
@@ -653,8 +653,8 @@ class TestLoadCsv(TestLoadBase):
     )
     def test_reload_with_overridden_types(self, Session):
         csv_filepath = get_sample_filepath("simple.csv")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         loader.load_csv(
             csv_filepath,
             resource_id=resource_id,
@@ -684,15 +684,15 @@ class TestLoadCsv(TestLoadBase):
             fields=fields, resource_id=resource_id, logger=logger
         )
 
-        assert len(self._get_records(Session, "test1")) == 6
-        assert self._get_column_names(Session, "test1") == [
+        assert len(self._get_records(Session, resource_id)) == 6
+        assert self._get_column_names(Session, resource_id) == [
             u"_id",
             u"_full_text",
             u"date",
             u"temperature",
             u"place",
         ]
-        assert self._get_column_types(Session, "test1") == [
+        assert self._get_column_types(Session, resource_id) == [
             u"int4",
             u"tsvector",
             u"timestamp",
@@ -702,7 +702,7 @@ class TestLoadCsv(TestLoadBase):
 
         # check that rows with nulls are indexed correctly
         records = self._get_records(
-            Session, "test1", exclude_full_text_column=False
+            Session, resource_id, exclude_full_text_column=False
         )
         print(records)
         assert records[4][1] == "'berkeley':1"
@@ -727,8 +727,8 @@ class TestLoadCsv(TestLoadBase):
 
     def test_column_names(self, Session):
         csv_filepath = get_sample_filepath("column_names.csv")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         loader.load_csv(
             csv_filepath,
             resource_id=resource_id,
@@ -736,12 +736,12 @@ class TestLoadCsv(TestLoadBase):
             logger=logger,
         )
 
-        assert self._get_column_names(Session, "test1")[2:] == [
+        assert self._get_column_names(Session, resource_id)[2:] == [
             u"d@t$e",
             u"t^e&m*pe!r(a)t?u:r%%e",
             r"p\l/a[c{e%",
         ]
-        assert self._get_records(Session, "test1")[0] == (
+        assert self._get_records(Session, resource_id)[0] == (
             1,
             u"2011-01-01",
             u"1",
@@ -752,8 +752,8 @@ class TestLoadCsv(TestLoadBase):
 class TestLoadUnhandledTypes(TestLoadBase):
     def test_kml(self):
         filepath = get_sample_filepath("polling_locations.kml")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         with pytest.raises(LoaderError) as exception:
             loader.load_csv(
                 filepath,
@@ -769,8 +769,8 @@ class TestLoadUnhandledTypes(TestLoadBase):
 
     def test_geojson(self):
         filepath = get_sample_filepath("polling_locations.geojson")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         with pytest.raises(LoaderError) as exception:
             loader.load_csv(
                 filepath,
@@ -791,8 +791,8 @@ class TestLoadUnhandledTypes(TestLoadBase):
     )
     def test_shapefile_zip_python2(self):
         filepath = get_sample_filepath("polling_locations.shapefile.zip")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         with pytest.raises(LoaderError):
             loader.load_csv(
                 filepath,
@@ -811,8 +811,8 @@ class TestLoadUnhandledTypes(TestLoadBase):
         # finds, 'Polling_Locations.cpg'. This file only contains the
         # following data: `UTF-8`.
         filepath = get_sample_filepath("polling_locations.shapefile.zip")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         loader.load_csv(
             filepath,
             resource_id=resource_id,
@@ -820,8 +820,8 @@ class TestLoadUnhandledTypes(TestLoadBase):
             logger=logger,
         )
 
-        assert self._get_records(Session, "test1") == []
-        assert self._get_column_names(Session, "test1") == [
+        assert self._get_records(Session, resource_id) == []
+        assert self._get_column_names(Session, resource_id) == [
             '_id',
             '_full_text',
             'UTF-8'
@@ -831,8 +831,8 @@ class TestLoadUnhandledTypes(TestLoadBase):
 class TestLoadTabulator(TestLoadBase):
     def test_simple(self, Session):
         csv_filepath = get_sample_filepath("simple.xls")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         loader.load_table(
             csv_filepath,
             resource_id=resource_id,
@@ -843,7 +843,7 @@ class TestLoadTabulator(TestLoadBase):
         assert (
             "'galway':"
             in self._get_records(
-                Session, "test1", limit=1, exclude_full_text_column=False
+                Session, resource_id, limit=1, exclude_full_text_column=False
             )[0][1]
         )
         # Indexed record looks like this (depending on CKAN version?):
@@ -851,7 +851,7 @@ class TestLoadTabulator(TestLoadBase):
         #   "'-01':4,5 '00':6,7,8 '1':1 '2011':3 'galway':2"
         #   "'-01':2,3 '00':5,6 '1':7 '2011':1 'galway':8 't00':4"
 
-        assert self._get_records(Session, "test1") == [
+        assert self._get_records(Session, resource_id) == [
             (1, datetime.datetime(2011, 1, 1, 0, 0), Decimal("1"), u"Galway",),
             (
                 2,
@@ -879,14 +879,14 @@ class TestLoadTabulator(TestLoadBase):
                 u"Berkeley",
             ),
         ]
-        assert self._get_column_names(Session, "test1") == [
+        assert self._get_column_names(Session, resource_id) == [
             u"_id",
             u"_full_text",
             u"date",
             u"temperature",
             u"place",
         ]
-        assert self._get_column_types(Session, "test1") == [
+        assert self._get_column_types(Session, resource_id) == [
             u"int4",
             u"tsvector",
             u"timestamp",
@@ -900,8 +900,8 @@ class TestLoadTabulator(TestLoadBase):
         # to get the test file:
         # curl -o ckanext/xloader/tests/samples/boston_311.csv https://data.boston.gov/dataset/8048697b-ad64-4bfc-b090-ee00169f2323/resource/2968e2c0-d479-49ba-a884-4ef523ada3c0/download/311.csv  # noqa
         csv_filepath = get_sample_filepath("boston_311.csv")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         import time
 
         t0 = time.time()
@@ -924,8 +924,8 @@ class TestLoadTabulator(TestLoadBase):
         # to create the test file:
         # head -n 100001 ckanext/xloader/tests/samples/boston_311.csv > ckanext/xloader/tests/samples/boston_311_sample5.csv
         csv_filepath = get_sample_filepath("boston_311_sample5.csv")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         import time
 
         t0 = time.time()
@@ -944,8 +944,8 @@ class TestLoadTabulator(TestLoadBase):
 
     def test_boston_311(self, Session):
         csv_filepath = get_sample_filepath("boston_311_sample.csv")
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         loader.load_table(
             csv_filepath,
             resource_id=resource_id,
@@ -953,7 +953,7 @@ class TestLoadTabulator(TestLoadBase):
             logger=logger,
         )
 
-        records = self._get_records(Session, "test1")
+        records = self._get_records(Session, resource_id)
         print(records)
         assert records == [
             (
@@ -1053,8 +1053,8 @@ class TestLoadTabulator(TestLoadBase):
                 u"Citizens Connect App",
             ),
         ]  # noqa
-        print(self._get_column_names(Session, "test1"))
-        assert self._get_column_names(Session, "test1") == [
+        print(self._get_column_names(Session, resource_id))
+        assert self._get_column_names(Session, resource_id) == [
             u"_id",
             u"_full_text",
             u"CASE_ENQUIRY_ID",
@@ -1087,8 +1087,8 @@ class TestLoadTabulator(TestLoadBase):
             u"Longitude",
             u"Source",
         ]  # noqa
-        print(self._get_column_types(Session, "test1"))
-        assert self._get_column_types(Session, "test1") == [
+        print(self._get_column_types(Session, resource_id))
+        assert self._get_column_types(Session, resource_id) == [
             u"int4",
             u"tsvector",
             u"numeric",
@@ -1126,8 +1126,8 @@ class TestLoadTabulator(TestLoadBase):
         csv_filepath = get_sample_filepath("no_entries.csv")
         # no datastore table is created - we need to except, or else
         # datastore_active will be set on a non-existent datastore table
-        resource_id = "test1"
-        factories.Resource(id=resource_id)
+        resource = factories.Resource()
+        resource_id = resource['id']
         with pytest.raises(LoaderError):
             loader.load_table(
                 csv_filepath,

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -11,7 +11,7 @@ from decimal import Decimal
 import ckan.plugins as p
 
 
-def resource_data(id, resource_id):
+def resource_data(id, resource_id, rows=None):
 
     if p.toolkit.request.method == "POST":
         try:
@@ -44,13 +44,16 @@ def resource_data(id, resource_id):
     except p.toolkit.NotAuthorized:
         return p.toolkit.abort(403, p.toolkit._("Not authorized to see this page"))
 
+    extra_vars = {
+        "status": xloader_status,
+        "resource": resource,
+        "pkg_dict": pkg_dict,
+    }
+    if rows:
+        extra_vars["rows"] = rows
     return p.toolkit.render(
         "xloader/resource_data.html",
-        extra_vars={
-            "status": xloader_status,
-            "resource": resource,
-            "pkg_dict": pkg_dict,
-        },
+        extra_vars=extra_vars,
     )
 
 

--- a/ckanext/xloader/views.py
+++ b/ckanext/xloader/views.py
@@ -1,5 +1,7 @@
 from flask import Blueprint
 
+from ckan.plugins.toolkit import request
+
 import ckanext.xloader.utils as utils
 
 
@@ -12,4 +14,12 @@ def get_blueprints():
 
 @xloader.route("/dataset/<id>/resource_data/<resource_id>", methods=("GET", "POST"))
 def resource_data(id, resource_id):
-    return utils.resource_data(id, resource_id)
+    rows = request.args.get('rows')
+    if rows:
+        try:
+            rows = int(rows)
+            if rows < 0:
+                rows = None
+        except ValueError:
+            rows = None
+    return utils.resource_data(id, resource_id, rows)


### PR DESCRIPTION
- Only show the first 50 and last 50 logs by default.
- Provide a count of the hidden rows and links to show more.
- This provides much better performance on large files, especially when using Tabulator.

Also includes some other fixes that are already present upstream.