### PR TITLE
Binary Type Support for Type Guessing

### DIFF
--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -47,6 +47,14 @@ groups:
         type: bool
         required: false
         legacy_key: ckanext.xloader.just_load_with_messytables
+      - key: ckanext.xloader.strict_type_guessing
+        default: True
+        example: False
+        description: |
+            Use with ckanext.xloader.use_type_guessing to set strict true or false
+            for type guessing. If set to False, the types will always fallback to string type.
+        type: bool
+        required: false
       - key: ckanext.xloader.parse_dates_dayfirst
         default: False
         example: False

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -343,7 +343,6 @@ _TYPE_MAPPING = {
     "<type 'bool'>": 'text',
     "<type 'int'>": 'numeric',
     "<type 'float'>": 'numeric',
-    "<type 'NoneType'>": 'text',  # (canada fork only): NoneType support
     "<type 'datetime.datetime'>": 'timestamp',  # (canada fork only): py2 support
     "<class 'decimal.Decimal'>": 'numeric',
     "<class 'str'>": 'text',
@@ -353,13 +352,12 @@ _TYPE_MAPPING = {
     "<class 'int'>": 'numeric',
     "<class 'float'>": 'numeric',
     "<class 'datetime.datetime'>": 'timestamp',
-    "<class 'NoneType'>": 'text',  # (canada fork only): NoneType support
 }
 
 
 def get_types():
-    # (canada fork only): NoneType support, Binary support
-    _TYPES = [int, bool, str, binary_type, datetime.datetime, float, Decimal, None]
+    # (canada fork only): Binary support
+    _TYPES = [int, bool, str, binary_type, datetime.datetime, float, Decimal]
     TYPE_MAPPING = config.get('TYPE_MAPPING', _TYPE_MAPPING)
     return _TYPES, TYPE_MAPPING
 

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -301,6 +301,12 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
                 res_id=resource_id))
             delete_datastore_resource(resource_id)
 
+        # (canada fork only): extra logging to show column types in reports
+        for field in zip(headers, types):
+            logger.info("Column '%s' type set to: %s",
+                        field[0],
+                        TYPE_MAPPING[str(field[1])])
+
         headers_dicts = [dict(id=field[0], type=TYPE_MAPPING[str(field[1])])
                          for field in zip(headers, types)]
 
@@ -338,17 +344,20 @@ _TYPE_MAPPING = {
     "<type 'bool'>": 'text',
     "<type 'int'>": 'numeric',
     "<type 'float'>": 'numeric',
+    "<type 'NoneType'>": 'text',  # (canada fork only): NoneType support, py2 support
+    "<type 'datetime.datetime'>": 'timestamp',  # (canada fork only): py2 support
     "<class 'decimal.Decimal'>": 'numeric',
     "<class 'str'>": 'text',
     "<class 'bool'>": 'text',
     "<class 'int'>": 'numeric',
     "<class 'float'>": 'numeric',
     "<class 'datetime.datetime'>": 'timestamp',
+    "<class 'NoneType'>": 'text',  # (canada fork only): NoneType support
 }
 
 
 def get_types():
-    _TYPES = [int, bool, str, datetime.datetime, float, Decimal]
+    _TYPES = [int, bool, str, datetime.datetime, float, Decimal, None]  # (canada fork only): NoneType support
     TYPE_MAPPING = config.get('TYPE_MAPPING', _TYPE_MAPPING)
     return _TYPES, TYPE_MAPPING
 

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -207,7 +207,12 @@ def type_guess(rows, types=TYPES, strict=False):
                     continue
                 at_least_one_value[ci] = True
                 for type in list(guesses[ci].keys()):
+                    # (canada fork only): NoneType support
+                    if type is None:
+                        type = None.__class__
                     if not isinstance(cell, type):
+                        if type is None.__class__:
+                            type = None  # switch back to None so pop is successful
                         guesses[ci].pop(type)
         # no need to set guessing weights before this
         # because we only accept a type if it never fails

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -184,8 +184,8 @@ def headers_guess(rows, tolerance=1):
     return 0, []
 
 
-# (canada fork only): NoneType support, Binary support
-TYPES = [int, bool, str, binary_type, datetime.datetime, float, Decimal, None]
+# (canada fork only): Binary support
+TYPES = [int, bool, str, binary_type, datetime.datetime, float, Decimal]
 
 def type_guess(rows, types=TYPES, strict=False):
     """ The type guesser aggregates the number of successful
@@ -212,12 +212,7 @@ def type_guess(rows, types=TYPES, strict=False):
                     continue
                 at_least_one_value[ci] = True
                 for type in list(guesses[ci].keys()):
-                    # (canada fork only): NoneType support
-                    if type is None:
-                        type = None.__class__
                     if not isinstance(cell, type):
-                        if type is None.__class__:
-                            type = None  # switch back to None so pop is successful
                         guesses[ci].pop(type)
         # no need to set guessing weights before this
         # because we only accept a type if it never fails
@@ -240,9 +235,6 @@ def type_guess(rows, types=TYPES, strict=False):
                 if not cell:
                     continue
                 for type in types:
-                    # (canada fork only): NoneType support
-                    if type is None:
-                        type = None.__class__
                     if isinstance(cell, type):
                         guesses[i][type] += 1
         _columns = []

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -3,6 +3,9 @@
 import json
 import datetime
 
+# (canada fork only): py2 support
+from six import text_type as str, binary_type
+
 from ckan import model
 from ckan.lib import search
 from collections import defaultdict
@@ -10,6 +13,8 @@ from decimal import Decimal
 
 import ckan.plugins as p
 from ckan.plugins.toolkit import config
+
+from .job_exceptions import JobError
 
 # resource.formats accepted by ckanext-xloader. Must be lowercase here.
 DEFAULT_FORMATS = [
@@ -179,8 +184,8 @@ def headers_guess(rows, tolerance=1):
     return 0, []
 
 
-TYPES = [int, bool, str, datetime.datetime, float, Decimal]
-
+# (canada fork only): NoneType support, Binary support
+TYPES = [int, bool, str, binary_type, datetime.datetime, float, Decimal, None]
 
 def type_guess(rows, types=TYPES, strict=False):
     """ The type guesser aggregates the number of successful
@@ -235,6 +240,9 @@ def type_guess(rows, types=TYPES, strict=False):
                 if not cell:
                     continue
                 for type in types:
+                    # (canada fork only): NoneType support
+                    if type is None:
+                        type = None.__class__
                     if isinstance(cell, type):
                         guesses[i][type] += 1
         _columns = []
@@ -245,5 +253,8 @@ def type_guess(rows, types=TYPES, strict=False):
         # element in case of a tie
         # See: http://stackoverflow.com/a/6783101/214950
         guesses_tuples = [(t, guess[t]) for t in types if t in guess]
+        # (canada fork only): raise on empty type guesses
+        if not guesses_tuples:
+            raise JobError('Failed to guess types')
         _columns.append(max(guesses_tuples, key=lambda t_n: t_n[1])[0])
     return _columns


### PR DESCRIPTION
Was able to solve the str vs unicode issues by adding in Binary type mapping and type. So in python 2 it will be able to map `unicode` and `str`. And then in python 3 it will still do `str`, but then do `bytes` as well.

I also added a config option for strict type guessing. The code has a `strict` param in the type guessing method, but it is only used in one place. So this will allow us to turn it on/off.

As far as I can tell, strict will fail if a parsed type does not match any of the mapped types in the code. And the not strict will always fallback to a string type.