### PR TITLE
Static Dialects Support

### DIFF
--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -158,7 +158,7 @@ def xloader_data_into_datastore_(input, job_dict):
     logger.info('File hash: %s', file_hash)
     resource['hash'] = file_hash
 
-    # (canada fork only): use custom ckanext.validaion.static_validation_options
+    # (canada fork only): use custom ckanext.validation.static_validation_options
     #                     to set static dialect and encoding for goodtables/frictionless/tabulator
     #                     or use the Resource's validation_options if they exist.
     # TODO: upstream contribution??

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -160,26 +160,29 @@ def xloader_data_into_datastore_(input, job_dict):
 
     # (canada fork only): use custom ckanext.validaion.static_validation_options
     #                     to set static dialect and encoding for goodtables/frictionless/tabulator
+    #                     or use the Resource's validation_options if they exist.
     # TODO: upstream contribution??
-    def _get_static_validation_options():
-        static_validation_options = {}
+    def _get_validation_options():
+        validation_options = {}
         static_validation_options = config.get(
             u'ckanext.validation.static_validation_options')
         if static_validation_options:
-            static_validation_options = json.loads(static_validation_options)
-        return static_validation_options
+            validation_options = json.loads(static_validation_options)
+        elif resource.get('validation_options', None):
+            validation_options = json.loads(resource.get('validation_options'))
+        return validation_options
 
     def direct_load():
-        static_options = _get_static_validation_options()
+        validation_options = _get_validation_options()
         fields = loader.load_csv(
             tmp_file.name,
             resource_id=resource['id'],
             mimetype=resource.get('format'),
-            # (canada fork only): adds in dialect argument to pass static dialect
-            dialect=static_options.get('dialect', {})
+            # (canada fork only): adds in dialect argument to pass static/resource dialect
+            dialect=validation_options.get('dialect', {})
                 .get(resource.get('format', '').lower(), None),
-            # (canada fork only): adds in encoding argument to pass static encoding
-            encoding=static_options.get('encoding', None),
+            # (canada fork only): adds in encoding argument to pass static/resource encoding
+            encoding=validation_options.get('encoding', None),
             logger=logger)
         loader.calculate_record_count(
             resource_id=resource['id'], logger=logger)
@@ -196,16 +199,16 @@ def xloader_data_into_datastore_(input, job_dict):
         logger.info('File Hash updated for resource: %s', resource['hash'])
 
     def tabulator_load():
-        static_options = _get_static_validation_options()
+        validation_options = _get_validation_options()
         try:
             loader.load_table(tmp_file.name,
                               resource_id=resource['id'],
                               mimetype=resource.get('format'),
-                              # (canada fork only): adds in dialect argument to pass static dialect
-                              dialect=static_options.get('dialect', {})
+                              # (canada fork only): adds in dialect argument to pass static/resource dialect
+                              dialect=validation_options.get('dialect', {})
                                 .get(resource.get('format', '').lower(), None),
-                              # (canada fork only): adds in encoding argument to pass static encoding
-                              encoding=static_options.get('encoding', None),
+                              # (canada fork only): adds in encoding argument to pass static/resource encoding
+                              encoding=validation_options.get('encoding', None),
                               logger=logger)
         except JobError as e:
             logger.error('Error during tabulator load: %s', e)

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -170,12 +170,16 @@ def xloader_data_into_datastore_(input, job_dict):
         return static_validation_options
 
     def direct_load():
+        static_options = _get_static_validation_options()
         fields = loader.load_csv(
             tmp_file.name,
             resource_id=resource['id'],
             mimetype=resource.get('format'),
             # (canada fork only): adds in dialect argument to pass static dialect
-            dialect=_get_static_validation_options().get('dialect', {})
+            dialect=static_options.get('dialect', {})
+                .get(resource.get('format', '').lower(), None),
+            # (canada fork only): adds in encoding argument to pass static encoding
+            encoding=static_options.get('encoding', {})
                 .get(resource.get('format', '').lower(), None),
             logger=logger)
         loader.calculate_record_count(
@@ -193,12 +197,16 @@ def xloader_data_into_datastore_(input, job_dict):
         logger.info('File Hash updated for resource: %s', resource['hash'])
 
     def tabulator_load():
+        static_options = _get_static_validation_options()
         try:
             loader.load_table(tmp_file.name,
                               resource_id=resource['id'],
                               mimetype=resource.get('format'),
                               # (canada fork only): adds in dialect argument to pass static dialect
-                              dialect=_get_static_validation_options().get('dialect', {})
+                              dialect=static_options.get('dialect', {})
+                                .get(resource.get('format', '').lower(), None),
+                              # (canada fork only): adds in encoding argument to pass static encoding
+                              encoding=static_options.get('encoding', {})
                                 .get(resource.get('format', '').lower(), None),
                               logger=logger)
         except JobError as e:

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -179,8 +179,7 @@ def xloader_data_into_datastore_(input, job_dict):
             dialect=static_options.get('dialect', {})
                 .get(resource.get('format', '').lower(), None),
             # (canada fork only): adds in encoding argument to pass static encoding
-            encoding=static_options.get('encoding', {})
-                .get(resource.get('format', '').lower(), None),
+            encoding=static_options.get('encoding', None),
             logger=logger)
         loader.calculate_record_count(
             resource_id=resource['id'], logger=logger)
@@ -206,8 +205,7 @@ def xloader_data_into_datastore_(input, job_dict):
                               dialect=static_options.get('dialect', {})
                                 .get(resource.get('format', '').lower(), None),
                               # (canada fork only): adds in encoding argument to pass static encoding
-                              encoding=static_options.get('encoding', {})
-                                .get(resource.get('format', '').lower(), None),
+                              encoding=static_options.get('encoding', None),
                               logger=logger)
         except JobError as e:
             logger.error('Error during tabulator load: %s', e)

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -163,6 +163,9 @@ def xloader_data_into_datastore_(input, job_dict):
             tmp_file.name,
             resource_id=resource['id'],
             mimetype=resource.get('format'),
+            # (canada fork only): adds in dialect argument to pass static dialect
+            dialect=resource.get('validation_options', {})
+                .get('dialect', {}).get(resource.get('format', '').lower(), None),
             logger=logger)
         loader.calculate_record_count(
             resource_id=resource['id'], logger=logger)
@@ -183,6 +186,9 @@ def xloader_data_into_datastore_(input, job_dict):
             loader.load_table(tmp_file.name,
                               resource_id=resource['id'],
                               mimetype=resource.get('format'),
+                              # (canada fork only): adds in dialect argument to pass static dialect
+                              dialect=resource.get('validation_options', {})
+                                .get('dialect', {}).get(resource.get('format', '').lower(), None),
                               logger=logger)
         except JobError as e:
             logger.error('Error during tabulator load: %s', e)

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -9,8 +9,6 @@ import os.path
 import tempfile
 from decimal import Decimal
 
-from json import dumps
-
 import psycopg2
 from chardet.universaldetector import UniversalDetector
 from six.moves import zip
@@ -44,6 +42,12 @@ class CanadaStream(Stream):
         self.static_dialect = kwargs.get('static_dialect', None)
         self.logger = kwargs.get('logger', None)
 
+    def _get_log_for_dialect(self, dialect):
+        log_dialect = ''
+        for _k in dialect:
+            log_dialect += '\n\t%s: %r' % (_k, dialect[_k])
+        return log_dialect
+
     @property
     def dialect(self):
         """Dialect (if available)
@@ -54,12 +58,12 @@ class CanadaStream(Stream):
         """
         if self.static_dialect:
             if self.logger:
-                self.logger.info('Using Static Dialect for %s: %s', self.__format, dumps(self.static_dialect))
+                self.logger.info('Using Static Dialect for %s: %s', self.__format, self._get_log_for_dialect(self.static_dialect))
             return self.static_dialect
         if self.__parser:
             if self.logger:
                 self.logger.info('Using Tabulator Dialect for %s: %s', self.__format,
-                                 dumps(getattr(self.__parser, 'dialect', {})))
+                                 self._get_log_for_dialect(getattr(self.__parser, 'dialect', {})))
             return getattr(self.__parser, 'dialect', {})
         return None
 
@@ -73,13 +77,15 @@ class UnknownEncodingStream(object):
     only to run into problems later in the file.
 
     (canada fork only): adds in dialect argument to pass static dialect
+                        adds in force_encoding to force decoding_result
                         adds in logger argument for extra logging
     """
 
-    def __init__(self, filepath, file_format, decoding_result, dialect=None, logger=None, **kwargs):
+    def __init__(self, filepath, file_format, decoding_result, dialect=None, force_encoding=False, logger=None, **kwargs):
         self.filepath = filepath
         self.file_format = file_format
         self.dialect = dialect
+        self.force_encoding = force_encoding
         self.logger = logger
         self.stream_args = kwargs
         self.decoding_result = decoding_result  # {'encoding': 'EUC-JP', 'confidence': 0.99}
@@ -97,6 +103,8 @@ class UnknownEncodingStream(object):
                                            ** self.stream_args).__enter__()
 
         except (EncodingError, UnicodeDecodeError):
+            if self.force_encoding:
+                raise EncodingError('File must be encoded with: %s' % self.decoding_result['encoding'])
             self.stream = CanadaStream(self.filepath, static_dialect=self.dialect, logger=self.logger,
                                        format=self.file_format, encoding=SINGLE_BYTE_ENCODING,
                                        custom_parsers={'csv': CanadaCSVParser}, **self.stream_args).__enter__()
@@ -160,16 +168,21 @@ def _clear_datastore_resource(resource_id):
         conn.execute('TRUNCATE TABLE "{}"'.format(resource_id))
 
 
-def load_csv(csv_filepath, resource_id, mimetype='text/csv', dialect=None, logger=None):
+def load_csv(csv_filepath, resource_id, mimetype='text/csv', dialect=None, encoding=None, logger=None):
     '''Loads a CSV into DataStore. Does not create the indexes.'''
 
-    decoding_result = detect_encoding(csv_filepath)
-    logger.info("load_csv: Decoded encoding: %s", decoding_result)
+    if not encoding:
+        decoding_result = detect_encoding(csv_filepath)
+        logger.info("load_csv: Decoded encoding: %s", decoding_result)
+    else:
+        decoding_result = {'confidence': 1.0, 'language': '', 'encoding': encoding}
+        logger.info("load_csv: Static encoding: %s", decoding_result)
     has_logged_dialect = False
     # Determine the header row
     try:
         file_format = os.path.splitext(csv_filepath)[1].strip('.')
         with UnknownEncodingStream(csv_filepath, file_format, decoding_result, dialect=dialect,
+                                   force_encoding=(True if encoding else False),
                                    logger=(logger if not has_logged_dialect else None)) as stream:
             header_offset, headers = headers_guess(stream.sample)
             has_logged_dialect = True
@@ -177,6 +190,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', dialect=None, logge
         try:
             file_format = mimetype.lower().split('/')[-1]
             with UnknownEncodingStream(csv_filepath, file_format, decoding_result, dialect=dialect,
+                                       force_encoding=(True if encoding else False),
                                        logger=(logger if not has_logged_dialect else None)) as stream:
                 header_offset, headers = headers_guess(stream.sample)
                 has_logged_dialect = True
@@ -213,6 +227,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', dialect=None, logge
         try:
             with UnknownEncodingStream(csv_filepath, file_format, decoding_result,
                                        skip_rows=skip_rows, dialect=dialect,
+                                       force_encoding=(True if encoding else False),
                                        logger=(logger if not has_logged_dialect else None)) as stream:
                 stream.save(**save_args)
                 has_logged_dialect = True
@@ -391,7 +406,7 @@ def _save_type_overrides(headers_dicts):
                 h['info'] = {'type_override': h['type']}
 
 
-def load_table(table_filepath, resource_id, mimetype='text/csv', dialect=None, logger=None):
+def load_table(table_filepath, resource_id, mimetype='text/csv', dialect=None, encoding=None, logger=None):
     '''Loads an Excel file (or other tabular data recognized by tabulator)
     into Datastore and creates indexes.
 
@@ -400,13 +415,18 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', dialect=None, l
 
     # Determine the header row
     logger.info('Determining column names and types')
-    decoding_result = detect_encoding(table_filepath)
-    logger.info("load_table: Decoded encoding: %s", decoding_result)
+    if not encoding:
+        decoding_result = detect_encoding(table_filepath)
+        logger.info("load_table: Decoded encoding: %s", decoding_result)
+    else:
+        decoding_result = {'confidence': 1.0, 'language': '', 'encoding': encoding}
+        logger.info("load_table: Static encoding: %s", decoding_result)
     has_logged_dialect = False
     try:
         file_format = os.path.splitext(table_filepath)[1].strip('.')
         with UnknownEncodingStream(table_filepath, file_format, decoding_result,
                                    post_parse=[TypeConverter().convert_types], dialect=dialect,
+                                   force_encoding=(True if encoding else False),
                                    logger=(logger if not has_logged_dialect else None)) as stream:
             header_offset, headers = headers_guess(stream.sample)
             has_logged_dialect = True
@@ -415,6 +435,7 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', dialect=None, l
             file_format = mimetype.lower().split('/')[-1]
             with UnknownEncodingStream(table_filepath, file_format, decoding_result,
                                        post_parse=[TypeConverter().convert_types], dialect=dialect,
+                                       force_encoding=(True if encoding else False),
                                        logger=(logger if not has_logged_dialect else None)) as stream:
                 header_offset, headers = headers_guess(stream.sample)
                 has_logged_dialect = True
@@ -460,6 +481,7 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', dialect=None, l
     with UnknownEncodingStream(table_filepath, file_format, decoding_result,
                                skip_rows=skip_rows,
                                post_parse=[type_converter.convert_types], dialect=dialect,
+                               force_encoding=(True if encoding else False),
                                logger=(logger if not has_logged_dialect else None)) as stream:
         has_logged_dialect = True
         def row_iterator():

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -42,12 +42,6 @@ class CanadaStream(Stream):
         self.static_dialect = kwargs.get('static_dialect', None)
         self.logger = kwargs.get('logger', None)
 
-    def _get_log_for_dialect(self, dialect):
-        log_dialect = ''
-        for _k in dialect:
-            log_dialect += '\n\t%s: %r' % (_k, dialect[_k])
-        return log_dialect
-
     @property
     def dialect(self):
         """Dialect (if available)
@@ -58,12 +52,12 @@ class CanadaStream(Stream):
         """
         if self.static_dialect:
             if self.logger:
-                self.logger.info('Using Static Dialect for %s: %s', self.__format, self._get_log_for_dialect(self.static_dialect))
+                self.logger.info('Using Static Dialect for %s: %r', self.__format, self.static_dialect)
             return self.static_dialect
         if self.__parser:
             if self.logger:
-                self.logger.info('Using Tabulator Dialect for %s: %s', self.__format,
-                                 self._get_log_for_dialect(getattr(self.__parser, 'dialect', {})))
+                self.logger.info('Using Tabulator Dialect for %s: %r', self.__format,
+                                 getattr(self.__parser, 'dialect', {}))
             return getattr(self.__parser, 'dialect', {})
         return None
 

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -176,7 +176,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', dialect=None, encod
     try:
         file_format = os.path.splitext(csv_filepath)[1].strip('.')
         with UnknownEncodingStream(csv_filepath, file_format, decoding_result, dialect=dialect,
-                                   force_encoding=(True if encoding else False),
+                                   force_encoding=bool(encoding),
                                    logger=(logger if not has_logged_dialect else None)) as stream:
             header_offset, headers = headers_guess(stream.sample)
             has_logged_dialect = True
@@ -184,7 +184,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', dialect=None, encod
         try:
             file_format = mimetype.lower().split('/')[-1]
             with UnknownEncodingStream(csv_filepath, file_format, decoding_result, dialect=dialect,
-                                       force_encoding=(True if encoding else False),
+                                       force_encoding=bool(encoding),
                                        logger=(logger if not has_logged_dialect else None)) as stream:
                 header_offset, headers = headers_guess(stream.sample)
                 has_logged_dialect = True
@@ -221,7 +221,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', dialect=None, encod
         try:
             with UnknownEncodingStream(csv_filepath, file_format, decoding_result,
                                        skip_rows=skip_rows, dialect=dialect,
-                                       force_encoding=(True if encoding else False),
+                                       force_encoding=bool(encoding),
                                        logger=(logger if not has_logged_dialect else None)) as stream:
                 stream.save(**save_args)
                 has_logged_dialect = True
@@ -420,7 +420,7 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', dialect=None, e
         file_format = os.path.splitext(table_filepath)[1].strip('.')
         with UnknownEncodingStream(table_filepath, file_format, decoding_result,
                                    post_parse=[TypeConverter().convert_types], dialect=dialect,
-                                   force_encoding=(True if encoding else False),
+                                   force_encoding=bool(encoding),
                                    logger=(logger if not has_logged_dialect else None)) as stream:
             header_offset, headers = headers_guess(stream.sample)
             has_logged_dialect = True
@@ -429,7 +429,7 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', dialect=None, e
             file_format = mimetype.lower().split('/')[-1]
             with UnknownEncodingStream(table_filepath, file_format, decoding_result,
                                        post_parse=[TypeConverter().convert_types], dialect=dialect,
-                                       force_encoding=(True if encoding else False),
+                                       force_encoding=bool(encoding),
                                        logger=(logger if not has_logged_dialect else None)) as stream:
                 header_offset, headers = headers_guess(stream.sample)
                 has_logged_dialect = True
@@ -475,7 +475,7 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', dialect=None, e
     with UnknownEncodingStream(table_filepath, file_format, decoding_result,
                                skip_rows=skip_rows,
                                post_parse=[type_converter.convert_types], dialect=dialect,
-                               force_encoding=(True if encoding else False),
+                               force_encoding=bool(encoding),
                                logger=(logger if not has_logged_dialect else None)) as stream:
         has_logged_dialect = True
         def row_iterator():

--- a/ckanext/xloader/parser.py
+++ b/ckanext/xloader/parser.py
@@ -63,17 +63,11 @@ class CanadaCSVParser(CSVParser):
         if self.static_dialect:
             self._CSVParser__prepare_dialect = self.__mangle__prepare_dialect
 
-    def _get_log_for_dialect(self, dialect):
-        log_dialect = ''
-        for _k in dialect:
-            log_dialect += '\n\t%s: %r' % (_k, dialect[_k])
-        return log_dialect
-
     @property
     def dialect(self):
         if self.static_dialect:
             if self.logger:
-                self.logger.info('Using Static Dialect for csv: %s', self._get_log_for_dialect(self.static_dialect))
+                self.logger.info('Using Static Dialect for csv: %r', self.static_dialect)
             return self.static_dialect
         return super(CanadaCSVParser, self).dialect()
 
@@ -92,7 +86,7 @@ class CanadaCSVParser(CSVParser):
                 break
 
         if self.logger:
-            self.logger.info('Using Static Dialect for csv: %s', self._get_log_for_dialect(self.static_dialect))
+            self.logger.info('Using Static Dialect for csv: %r', self.static_dialect)
 
         return sample, CanadaCSVDialect(self.static_dialect)
 

--- a/ckanext/xloader/parser.py
+++ b/ckanext/xloader/parser.py
@@ -26,7 +26,7 @@ class CanadaCSVDialect(Dialect):
 
     _name = 'csv'
 
-    def __init__(self, static_dialect=None):
+    def __init__(self, static_dialect):
         super(CanadaCSVDialect, self).__init__()
         for k in static_dialect:
             setattr(self, k, static_dialect[k])

--- a/ckanext/xloader/parser.py
+++ b/ckanext/xloader/parser.py
@@ -4,8 +4,6 @@ from decimal import Decimal, InvalidOperation
 import re
 import six
 
-from json import dumps
-
 from ckan.plugins.toolkit import asbool
 from dateutil.parser import isoparser, parser, ParserError
 
@@ -65,12 +63,17 @@ class CanadaCSVParser(CSVParser):
         if self.static_dialect:
             self._CSVParser__prepare_dialect = self.__mangle__prepare_dialect
 
+    def _get_log_for_dialect(self, dialect):
+        log_dialect = ''
+        for _k in dialect:
+            log_dialect += '\n\t%s: %r' % (_k, dialect[_k])
+        return log_dialect
 
     @property
     def dialect(self):
         if self.static_dialect:
             if self.logger:
-                self.logger.info('Using Static Dialect for csv: %s', dumps(self.static_dialect))
+                self.logger.info('Using Static Dialect for csv: %s', self._get_log_for_dialect(self.static_dialect))
             return self.static_dialect
         return super(CanadaCSVParser, self).dialect()
 
@@ -89,7 +92,7 @@ class CanadaCSVParser(CSVParser):
                 break
 
         if self.logger:
-            self.logger.info('Using Static Dialect for csv: %s', dumps(self.static_dialect))
+            self.logger.info('Using Static Dialect for csv: %s', self._get_log_for_dialect(self.static_dialect))
 
         return sample, CanadaCSVDialect(self.static_dialect)
 

--- a/ckanext/xloader/parser.py
+++ b/ckanext/xloader/parser.py
@@ -69,7 +69,7 @@ class CanadaCSVParser(CSVParser):
             if self.logger:
                 self.logger.info('Using Static Dialect for csv: %r', self.static_dialect)
             return self.static_dialect
-        return super(CanadaCSVParser, self).dialect()
+        return super(CanadaCSVParser, self).dialect
 
     def __mangle__prepare_dialect(self, stream):
 


### PR DESCRIPTION
feat(dev): use static dialects;

- Started working on using the static dialects from the validation_options field.

Won't do much by itself, but offers that ability to use the dialects from the ckanext-validation plugin's `validation_options` field. https://github.com/open-data/ckanext-canada/pull/1430 <- this PR now sets static ones in an output validator. (https://github.com/open-data/ckanext-canada/pull/1430/commits/a63a46a5765476a3a4fd078385144b889e3fdd74)

Makes sense to use the `validation_options` field as the ckanext-validation uses goodtables/frictionless which just passes it all along to the Tabulator lib. And the ckanext-xloader also uses the Tabulator lib.

Still a work in progress as the subclassing for the Tabulator Streams and Parsers are tricky. Still trying to figure out how to get the `dialect` class property method to work...does not seem to be firing off. I imagine it is because the CSV parser method has some strange `__prepare_dialect` method that is not really using the `dialect` class method at all. So will have to most likely subclass that as well, and use `custom_parsers` argument to the `Stream` classes