### PR TITLE
Underscored Columns Names

### DIFF
--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -161,7 +161,8 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
     # e.g. duplicate names
     # (canada fork only): not worrrying about dupes as that is handled in ckanext-validation
 
-    # (canada fork only): remove underscores from front of headers as it is not supported in psql/datastore
+    # (canada fork only): remove underscores from front of headers as it is not supported in datastore
+    #                     see: ckanext.datastore.helpers.is_valid_field_name
     for i, header in enumerate(headers):
         if header.startswith('_'):
             headers[i] = header.lstrip('_')
@@ -417,7 +418,8 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
     # e.g. duplicate names
     # (canada fork only): not worrrying about dupes as that is handled in ckanext-validation
 
-    # (canada fork only): remove underscores from front of headers as it is not supported in psql/datastore
+    # (canada fork only): remove underscores from front of headers as it is not supported in datastore
+    #                     see: ckanext.datastore.helpers.is_valid_field_name
     for i, header in enumerate(headers):
         if header.startswith('_'):
             headers[i] = header.lstrip('_')

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -159,6 +159,12 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
 
     # TODO worry about csv header name problems
     # e.g. duplicate names
+    # (canada fork only): not worrrying about dupes as that is handled in ckanext-validation
+
+    # (canada fork only): remove underscores from front of headers as it is not supported in psql/datastore
+    for i, header in enumerate(headers):
+        if header.startswith('_'):
+            headers[i] = header.lstrip('_')
 
     # encoding (and line ending?)- use chardet
     # It is easier to reencode it as UTF8 than convert the name of the encoding
@@ -406,6 +412,15 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
 
     headers = [header.strip()[:MAX_COLUMN_LENGTH] for header in headers if header.strip()]
     type_converter = TypeConverter(types=types)
+
+    # TODO worry about csv header name problems
+    # e.g. duplicate names
+    # (canada fork only): not worrrying about dupes as that is handled in ckanext-validation
+
+    # (canada fork only): remove underscores from front of headers as it is not supported in psql/datastore
+    for i, header in enumerate(headers):
+        if header.startswith('_'):
+            headers[i] = header.lstrip('_')
 
     with UnknownEncodingStream(table_filepath, file_format, decoding_result,
                                skip_rows=skip_rows,


### PR DESCRIPTION
feat(dev): remove leading underscores;

- Removed leading underscores when loading into DS.

@wardi so it turns out that just all underscore prefixed column names will error out. So just doing a simple `lstrip` on underscores fixes that. Granted, the way I did it would not catch duplicate header names after the stripping. Not sure if we care enough about that? 

If so, instead of just stripping the underscores, we could add a small nonce to the begging of them based on the number of underscore-prefixed header names?

OH, also it turns out that sqlalchemy escapes reserved names. I created a CSV with a bunch of psql reserved names as the column names, and it loaded through validation and xloader into the datastore just fine. And the datatable views and dumps work fine.

```
def is_valid_field_name(name):
    '''
    Check that field name is valid:
    * can't start or end with whitespace characters
    * can't start with underscore
    * can't contain double quote (")
    * can't be empty
    '''
    return (name and name == name.strip() and
            not name.startswith('_') and
            '"' not in name)
```
so just have to really deal with this above check from the DataStore plugin. Let me know if you think we should just do the underscore replacements here in Xloader, or also do more replacements.

OR if we should just add to ckanext-validation and call `is_valid_field_name` on all the headers there. Could make an upstream PR to validation with a config option like `ckanext.validation.validate_ds_headers`