### PR TITLE
Strip Trailing White Space

### DIFF
--- a/changes/26.canada.feature
+++ b/changes/26.canada.feature
@@ -1,0 +1,1 @@
+Leading and trailing white space now gets removed from cell values when loading into the DataStore.

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -356,7 +356,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', dialect=None, encod
                         error_str = str(e)
                         logger.warning(error_str)
                         raise LoaderError('Error during the load into PostgreSQL:'
-                                        ' {}'.format(error_str))
+                                          ' {}'.format(error_str))
 
             finally:
                 cur.close()


### PR DESCRIPTION
fix(loader): strip trailing whitespace;

- Strip trailing white space from cell values when loading into the DataStore.